### PR TITLE
Fix three bugs in na update --plugin

### DIFF
--- a/bin/commands/update.rb
+++ b/bin/commands/update.rb
@@ -297,7 +297,7 @@ class App
             # Track which candidates have been matched to avoid duplicates
             selected_indices = []
             candidate_actions.each_index do |i|
-              if selected.include?(candidate_actions[i])
+              if selected.include?(candidate_actions[i].strip)
                 selected_indices << i unless selected_indices.include?(i)
               end
             end
@@ -328,7 +328,8 @@ class App
         options[:edit],
         options[:started],
         (options[:end] || options[:finished]),
-        options[:duration]
+        options[:duration],
+        !options[:plugin].nil?
       ].any?
       unless actionable
         # Interactive menu for actions

--- a/lib/na/next_action.rb
+++ b/lib/na/next_action.rb
@@ -37,7 +37,7 @@ module NA
       action_args = Array(action_block['arguments'])
 
       # Load current action
-      _projects, actions = find_actions(file, nil, nil, all: true, done: true, project: nil, search_note: true, target_line: line)
+      _projects, actions = find_actions(file, nil, nil, done: true, project: nil, search_note: true, target_line: line)
       action = actions&.first
       return unless action
 


### PR DESCRIPTION
## Summary

- **Bug 1** (`bin/commands/update.rb`): After fzf returns selected lines, they are stripped with `.strip` before comparison — but `candidate_actions[i]` is not. Any trailing whitespace in a task's action text causes the match to fail, leaving `selected_indices` empty and throwing "No matching actions found for selection". Fix: add `.strip` to `candidate_actions[i]` in the comparison.

- **Bug 2** (`lib/na/next_action.rb`): `apply_plugin_result` calls `find_actions` with `all: true` and `target_line`. In `find_actions`, the early return for `all: true` fires before `target_line` is ever checked, so `actions.first` is always the first task in the file rather than the selected one. Fix: remove `all: true` from that call.

- **Bug 3** (`bin/commands/update.rb`): `options[:plugin]` is missing from the `actionable` check. When `--plugin` is passed on the CLI, `actionable` is still `false`, causing the interactive "Add Tag / Remove Tag / … / Run Plugin" menu to appear even though the plugin was already specified. Fix: add `!options[:plugin].nil?` to the `actionable` array.

All three were discovered while testing a custom Reminders.app plugin (`na update -d 3 --plugin "Add Reminder"`).